### PR TITLE
Correct unit for Energy to be kWh instead of Wh

### DIFF
--- a/dbus-fronius-smartmeter.py
+++ b/dbus-fronius-smartmeter.py
@@ -59,8 +59,8 @@ class DbusDummyService:
     self._dbusservice['/Ac/L1/Power'] = meter_data['Body']['Data']['PowerReal_P_Phase_1']
     self._dbusservice['/Ac/L2/Power'] = meter_data['Body']['Data']['PowerReal_P_Phase_2']
     self._dbusservice['/Ac/L3/Power'] = meter_data['Body']['Data']['PowerReal_P_Phase_3']
-    self._dbusservice['/Ac/Energy/Forward'] = meter_data['Body']['Data']['EnergyReal_WAC_Sum_Consumed']
-    self._dbusservice['/Ac/Energy/Reverse'] = meter_data['Body']['Data']['EnergyReal_WAC_Sum_Produced']
+    self._dbusservice['/Ac/Energy/Forward'] = float(meter_data['Body']['Data']['EnergyReal_WAC_Sum_Consumed'])/1000
+    self._dbusservice['/Ac/Energy/Reverse'] = float(meter_data['Body']['Data']['EnergyReal_WAC_Sum_Produced'])/1000
     logging.info("House Consumption: %s" % (MeterConsumption))
     return True
 


### PR DESCRIPTION
Otherwise the numbers in VRM are off by a factor of 1000