### PR TITLE
Augment servicename for dbus service

### DIFF
--- a/dbus-fronius-smartmeter.py
+++ b/dbus-fronius-smartmeter.py
@@ -104,7 +104,7 @@ def main():
   DBusGMainLoop(set_as_default=True)
 
   pvac_output = DbusDummyService(
-    servicename='com.victronenergy.grid',
+    servicename='com.victronenergy.grid.mymeter',
     deviceinstance=0,
     paths={
       '/Ac/Power': {'initial': 0},


### PR DESCRIPTION
In my installation on a venusOS @ raspi this change was neccessary for venusOS to include the meter as grid meter values in the control and the visu. This is also needed when you want to run the system in ESS mode.

Additional infos:
- [Place in dbus-systemcalc-py](https://github.com/victronenergy/dbus-systemcalc-py/blob/56c2725f8c6d643f589892acfc2f82d53b7b28c9/delegates/acinput.py#L69) where the name is checked.
- [Comment in dbus-systemcalc-py](https://github.com/victronenergy/dbus-systemcalc-py/blob/56c2725f8c6d643f589892acfc2f82d53b7b28c9/dbus_systemcalc.py#L879) that references to that behaviour